### PR TITLE
Pin openzeppelin to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "homepage": "https://github.com/chatch/hashed-timelock-contract-ethereum#README.md",
   "dependencies": {
-    "openzeppelin-solidity": "^2.1.2"
+    "openzeppelin-solidity": "2.3.0"
   },
   "devDependencies": {
     "eslint": "^5.13.0",


### PR DESCRIPTION
2.4.0 has changes to dependencies that would require updates on our side
to successfully build tokenswap etc.